### PR TITLE
Fixed taxonomy permalinks yield 404 errors.

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 /*
   Plugin Name: WooCommerce Permalink Structure
   Plugin URI: http://wordpress.org/plugins/woocommerce-permalink-structure/
-  Version: 1.0.2
+  Version: 1.0.3
   Text Domain: woocommerce-permalink-structure
   Description: Allows WooCommerce products to have the same permalink path prefix as product categories and the shop base page; i.e., '/shop/category/subcategory/product-name'. Adjusts internal WordPress rewrite rule structure; not necessarily compatible with all plugins and shop configurations.
   Author: Daniel F. Kudwien (sun)

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -29,7 +29,7 @@ class Plugin {
    */
   public static function init() {
     add_filter('query_vars', __CLASS__ . '::query_vars');
-    add_filter('rewrite_rules_array', __CLASS__ . '::rewrite_rules_array', 100);
+    add_filter('product_rewrite_rules', __CLASS__ . '::product_rewrite_rules', 100);
     add_filter('request', __CLASS__ . '::request', 1);
   }
 
@@ -42,9 +42,9 @@ class Plugin {
   }
 
   /**
-   * @implements rewrite_rules_array
+   * @implements product_rewrite_rules
    */
-  public static function rewrite_rules_array(array $rules) {
+  public static function product_rewrite_rules(array $rules) {
     $rules = [
       // Same as default rewrite rule for product categories with default config
       // '%product_cat%/$postname%' for product permalinks, but additionally

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -29,6 +29,8 @@ class Plugin {
    */
   public static function init() {
     add_filter('query_vars', __CLASS__ . '::query_vars');
+    // Add rewrite rules at the beginning of the product rules to not mistakenly
+    // match the product taxonomy ones which are defined upfront.
     add_filter('product_rewrite_rules', __CLASS__ . '::product_rewrite_rules', 100);
     add_filter('request', __CLASS__ . '::request', 1);
   }


### PR DESCRIPTION
Moved the rewrite rule prior the general product rules to take precedence.