### PR TITLE
Fixed trailing slash in password reset link causes redirect.

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 /*
   Plugin Name: WooCommerce Permalink Structure
   Plugin URI: http://wordpress.org/plugins/woocommerce-permalink-structure/
-  Version: 1.0.3
+  Version: 1.1.0
   Text Domain: woocommerce-permalink-structure
   Description: Allows WooCommerce products to have the same permalink path prefix as product categories and the shop base page; i.e., '/shop/category/subcategory/product-name'. Adjusts internal WordPress rewrite rule structure; not necessarily compatible with all plugins and shop configurations.
   Author: Daniel F. Kudwien (sun)

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -33,6 +33,8 @@ class Plugin {
     // match the product taxonomy ones which are defined upfront.
     add_filter('product_rewrite_rules', __CLASS__ . '::product_rewrite_rules', 100);
     add_filter('request', __CLASS__ . '::request', 1);
+    // Removes trailing slash from password reset and other links to avoid redirects.
+    add_filter('woocommerce_get_endpoint_url', __NAMESPACE__ . '\WooCommerce::woocommerce_get_endpoint_url', 10, 4);
   }
 
   /**
@@ -78,6 +80,21 @@ class Plugin {
       }
     }
     return $query_vars;
+  }
+
+  /**
+   * Removes trailing slash from links to WooCommerce password reset and other pages.
+   *
+   * WooCommerce appends a trailing slash to the password reset and other special
+   * pages, which causes an unnecesary redirect for users.
+   *
+   * @implements woocommerce_get_endpoint_url
+   */
+  public static function woocommerce_get_endpoint_url($url, $endpoint, $value, $permalink) {
+    if (!$value) {
+      $url = untrailingslashit($url);
+    }
+    return $url;
   }
 
   /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -33,6 +33,7 @@ class Plugin {
     // match the product taxonomy ones which are defined upfront.
     add_filter('product_rewrite_rules', __CLASS__ . '::product_rewrite_rules', 100);
     add_filter('request', __CLASS__ . '::request', 1);
+
     // Removes trailing slash from password reset and other links to avoid redirects.
     add_filter('woocommerce_get_endpoint_url', __NAMESPACE__ . '\WooCommerce::woocommerce_get_endpoint_url', 10, 4);
   }
@@ -86,7 +87,7 @@ class Plugin {
    * Removes trailing slash from links to WooCommerce password reset and other pages.
    *
    * WooCommerce appends a trailing slash to the password reset and other special
-   * pages, which causes an unnecesary redirect for users.
+   * pages, which causes an unnecessary redirect for users.
    *
    * @implements woocommerce_get_endpoint_url
    */


### PR DESCRIPTION
Problem
* The link to the password reset page generated by WooCommerce contains a trailing slash, which causes an unnecessary redirect when accessing it, because the actual permalink pattern for pages does not use trailing slashes.

Proposed solution
1. Remove the trailing slash from links generated by WooCommerce.