### PR TITLE
Fixed 404 errors for WooCommerce pages if they are children of the /shop page.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -55,7 +55,7 @@ class Plugin {
       // '%product_cat%/$postname%' for product permalinks, but additionally
       // records the full category/product-name path, so it can be used as a
       // fallback in request().
-      'shop((?:/[^/]+?)*?/(?!checkout)([^/]+?))(/page/([0-9]+))?/?$' => 'index.php?product_cat=$matches[2]&paged=$matches[4]&product_cat_and_post_name=$matches[1]',
+      'shop((?:/[^/]+?)*?/([^/]+?))(/page/([0-9]+))?/?$' => 'index.php?product_cat=$matches[2]&paged=$matches[4]&product_cat_and_post_name=$matches[1]',
     ] + $rules;
     return $rules;
   }
@@ -67,6 +67,10 @@ class Plugin {
    */
   public static function request(array $query_vars) {
     if (isset($query_vars['product_cat']) && $query_vars['product_cat'] !== '' && !term_exists($query_vars['product_cat'], 'product_cat')) {
+      $pagename = 'shop/' . ltrim($query_vars['product_cat_and_post_name'], '/');
+       if ($post = get_page_by_path($pagename)) {
+        return ['p' => $post->ID];
+      }
       // The regular rewrite rule for products is:
       //   shop/(.+?)/([^/]+)(?:/([0-9]+))?/?$	index.php?product_cat=$matches[1]&product=$matches[2]&page=$matches[3]	product
       $query_vars['post_type'] = 'product';

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -55,7 +55,7 @@ class Plugin {
       // '%product_cat%/$postname%' for product permalinks, but additionally
       // records the full category/product-name path, so it can be used as a
       // fallback in request().
-      'shop((?:/[^/]+?)*?/([^/]+?))(/page/([0-9]+))?/?$' => 'index.php?product_cat=$matches[2]&paged=$matches[4]&product_cat_and_post_name=$matches[1]',
+      'shop((?:/[^/]+?)*?/(?!checkout)([^/]+?))(/page/([0-9]+))?/?$' => 'index.php?product_cat=$matches[2]&paged=$matches[4]&product_cat_and_post_name=$matches[1]',
     ] + $rules;
     return $rules;
   }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -67,6 +67,7 @@ class Plugin {
    */
   public static function request(array $query_vars) {
     if (isset($query_vars['product_cat']) && $query_vars['product_cat'] !== '' && !term_exists($query_vars['product_cat'], 'product_cat')) {
+      // If the requested path is a child of the shop page query the page instead of a category or product.
       $pagename = static::getCategoryBase() . '/' . ltrim($query_vars['product_cat_and_post_name'], '/');
       if ($post = get_page_by_path($pagename)) {
         return ['page_id' => $post->ID];

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -55,7 +55,7 @@ class Plugin {
       // '%product_cat%/$postname%' for product permalinks, but additionally
       // records the full category/product-name path, so it can be used as a
       // fallback in request().
-      'shop((?:/[^/]+?)*?/([^/]+?))(/page/([0-9]+))?/?$' => 'index.php?product_cat=$matches[2]&paged=$matches[4]&product_cat_and_post_name=$matches[1]',
+      static::getCategoryBase() . '((?:/[^/]+?)*?/([^/]+?))(/page/([0-9]+))?/?$' => 'index.php?product_cat=$matches[2]&paged=$matches[4]&product_cat_and_post_name=$matches[1]',
     ] + $rules;
     return $rules;
   }
@@ -67,9 +67,9 @@ class Plugin {
    */
   public static function request(array $query_vars) {
     if (isset($query_vars['product_cat']) && $query_vars['product_cat'] !== '' && !term_exists($query_vars['product_cat'], 'product_cat')) {
-      $pagename = 'shop/' . ltrim($query_vars['product_cat_and_post_name'], '/');
-       if ($post = get_page_by_path($pagename)) {
-        return ['p' => $post->ID];
+      $pagename = static::getCategoryBase() . '/' . ltrim($query_vars['product_cat_and_post_name'], '/');
+      if ($post = get_page_by_path($pagename)) {
+        return ['page_id' => $post->ID];
       }
       // The regular rewrite rule for products is:
       //   shop/(.+?)/([^/]+)(?:/([0-9]+))?/?$	index.php?product_cat=$matches[1]&product=$matches[2]&page=$matches[3]	product
@@ -100,6 +100,16 @@ class Plugin {
       $url = untrailingslashit($url);
     }
     return $url;
+  }
+
+  /*
+   * Returns the WooCommerce category permalink base.
+   *
+   * @return string
+   */
+  public static function getCategoryBase(): string {
+    $permalinks = (array) get_option('woocommerce_permalinks');
+    return $permalinks['category_base'] ?? 'shop';
   }
 
   /**


### PR DESCRIPTION
## Issue summary
- If the base domain already contains `shop`, the checkout page permalink is wrongly treated as a product category permalink

## How to reproduce the issue
- Install and activate the plugin on a website which domain is `domain.test/shop`
- Try to reach the checkout page. A 404 error will appear.

## Proposed solution
1. Modify the existing regex to exclude checkout page.