### PR TITLE
Fixed PHP warnings due to missing queried object when accessing child page of shop page

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -67,10 +67,13 @@ class Plugin {
    */
   public static function request(array $query_vars) {
     if (isset($query_vars['product_cat']) && $query_vars['product_cat'] !== '' && !term_exists($query_vars['product_cat'], 'product_cat')) {
-      // If the requested path is a child of the shop page query the page instead of a category or product.
+      // If the requested path is a child page of the shop page then query that
+      // page instead of a category or product.
       $pagename = static::getCategoryBase() . '/' . ltrim($query_vars['product_cat_and_post_name'], '/');
-      if ($post = get_page_by_path($pagename)) {
-        return ['page_id' => $post->ID];
+      if (get_page_by_path($pagename)) {
+        // page_id would be much better for performance (avoiding another lookup
+        // by post_name), but WP_Query does not populate queried_object with it.
+        return ['pagename' => $pagename];
       }
       // The regular rewrite rule for products is:
       //   shop/(.+?)/([^/]+)(?:/([0-9]+))?/?$	index.php?product_cat=$matches[1]&product=$matches[2]&page=$matches[3]	product


### PR DESCRIPTION
Problem
* On the /shop/checkout page and many other pages, 10-20 PHP warnings appear at the top of the page.

Cause
* #3 introduced support for the cart and checkout page to be located below the shop page. But the `page_id` query parameter used in the main query does not populate the queried_object parameter, causing it to be NULL (even though there is a page result found), and thus all other checks relying on `get_queried_object()`, such as `is_page()` and other context checks, are triggering PHP warnings.

Proposed solution
1. Use `pagename` instead of `page_id`.

Notes

* The proposed solution has a negative impact on performance.

* As `pagename` is the parameter used by the built-in route / rewrite rule; WP_Query probably implements special support for that parameter, triggering the queried object to get populated. It's possible that this behavior can be mimicked through custom code. Feel free to create a new PR to follow-up on the solution proposed here that works with `page_id` again.