### PR TITLE
Fixed rewrite rule does not override core rewrite rules with latest WooCommerce anymore.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -29,9 +29,9 @@ class Plugin {
    */
   public static function init() {
     add_filter('query_vars', __CLASS__ . '::query_vars');
-    // Add rewrite rules at the beginning of the product rules to not mistakenly
-    // match the product taxonomy ones which are defined upfront.
-    add_filter('product_rewrite_rules', __CLASS__ . '::product_rewrite_rules', 100);
+    // Add rewrite rules at the beginning of the product category rules to not
+    // mistakenly match the product taxonomy ones which are defined upfront.
+    add_filter('product_cat_rewrite_rules', __CLASS__ . '::product_rewrite_rules', 100);
     add_filter('request', __CLASS__ . '::request', 1);
 
     // Force WooCommerce to assume that the product permalink base path is
@@ -74,13 +74,13 @@ class Plugin {
    * @implements request
    */
   public static function request(array $query_vars) {
-    if (isset($query_vars['product_cat']) && $query_vars['product_cat'] !== '' && !term_exists($query_vars['product_cat'], 'product_cat')) {
+    if (isset($query_vars['product_cat_and_post_name']) && isset($query_vars['product_cat'])
+      && $query_vars['product_cat'] !== ''
+      && !term_exists($query_vars['product_cat'], 'product_cat')) {
       // If the requested path is a child page of the shop page then query that
       // page instead of a category or product.
       $pagename = static::getCategoryBase();
-      if (isset($query_vars['product_cat_and_post_name'])) {
-        $pagename .= '/' . ltrim($query_vars['product_cat_and_post_name'], '/');
-      }
+      $pagename .= '/' . ltrim($query_vars['product_cat_and_post_name'], '/');
       if (get_page_by_path($pagename)) {
         // page_id would be much better for performance (avoiding another lookup
         // by post_name), but WP_Query does not populate queried_object with it.
@@ -91,9 +91,7 @@ class Plugin {
       $query_vars['post_type'] = 'product';
       $query_vars['product'] = $query_vars['product_cat'];
       $query_vars['name'] = $query_vars['product'];
-      if (isset($query_vars['product_cat_and_post_name'])) {
-        $query_vars['product_cat'] = trim(strtr($query_vars['product_cat_and_post_name'], [$query_vars['product_cat'] => '']), '/');
-      }
+      $query_vars['product_cat'] = trim(strtr($query_vars['product_cat_and_post_name'], [$query_vars['product_cat'] => '']), '/');
 
       // Also rewrite the paging parameter from categories to posts/pages.
       if (isset($query_vars['paged'])) {


### PR DESCRIPTION
### Ticket
- [All product pages are showing shop page after activating shop page](https://app.asana.com/0/778711864579963/1201485647670936/f)

### Description
- As late debugging in https://github.com/netzstrategen/woocommerce-permalink-structure/pull/8#issuecomment-1033017916 showed, a (not so) recent WooCommerce version apparently changed the rewrite rule permastruct from "product" to "product_cat".

Proposed solution
1. Updating the permastruct hook from "product" to "product_cat" fixes the registration, so that our override is applied before the regular core rewrite rules.
2. We can revert the changes from #8.  But wrap the whole function into a condition for our required rewrite rule parameter – if that doesn't exist, then our rule did not match and isn't supposed to interfere with the query.

With this, the rewrite rules are overridden as expected again (note that the shop page has the slug "abo" in this example):
```console
$ wp rewrite list --match=abo
+--------------------------+-------------------------------------------------+--------+
| match                    | query                                           | source |
+--------------------------+-------------------------------------------------+--------+
| (.?.+?)(?:/([0-9]+))?/?$ | index.php?pagename=$matches[1]&page=$matches[2] | page   |
| (.+?)/?$                 | index.php?category_name=$matches[1]             | post   |
+--------------------------+-------------------------------------------------+--------+

$ wp rewrite list --match=abo/product
+-------------------------------------------------+-------------------------------------------------------------------------------------------+-------------+
| match                                           | query                                                                                     | source      |
+-------------------------------------------------+-------------------------------------------------------------------------------------------+-------------+
| abo((?:/[^/]+?)*?/([^/]+?))(/page/([0-9]+))?/?$ | index.php?product_cat=$matches[2]&paged=$matches[4]&product_cat_and_post_name=$matches[1] | product_cat |
| abo/(.+?)/?$                                    | index.php?product_cat=$matches[1]                                                         | product_cat |
| abo/([^/]+)(?:/([0-9]+))?/?$                    | index.php?product=$matches[1]&page=$matches[2]                                            | product     |
| (.?.+?)(?:/([0-9]+))?/?$                        | index.php?pagename=$matches[1]&page=$matches[2]                                           | page        |
| (.+?)/([^/]+)(?:/([0-9]+))?/?$                  | index.php?category_name=$matches[1]&name=$matches[2]&page=$matches[3]                     | post        |
| (.+?)/?$                                        | index.php?category_name=$matches[1]                                                       | post        |
+-------------------------------------------------+-------------------------------------------------------------------------------------------+-------------+

$ wp rewrite list --match=abo/category/product
+-------------------------------------------------+-------------------------------------------------------------------------------------------+-------------+
| match                                           | query                                                                                     | source      |
+-------------------------------------------------+-------------------------------------------------------------------------------------------+-------------+
| abo((?:/[^/]+?)*?/([^/]+?))(/page/([0-9]+))?/?$ | index.php?product_cat=$matches[2]&paged=$matches[4]&product_cat_and_post_name=$matches[1] | product_cat |
| abo/(.+?)/?$                                    | index.php?product_cat=$matches[1]                                                         | product_cat |
| abo/[^/]+/([^/]+)/?$                            | index.php?attachment=$matches[1]                                                          | product     |
| (.?.+?)(?:/([0-9]+))?/?$                        | index.php?pagename=$matches[1]&page=$matches[2]                                           | page        |
| (.+?)/([^/]+)(?:/([0-9]+))?/?$                  | index.php?category_name=$matches[1]&name=$matches[2]&page=$matches[3]                     | post        |
| .+?/[^/]+/([^/]+)/?$                            | index.php?attachment=$matches[1]                                                          | post        |
| (.+?)/?$                                        | index.php?category_name=$matches[1]                                                       | post        |
+-------------------------------------------------+-------------------------------------------------------------------------------------------+-------------+
```
