### PR TITLE
Fixed shop page does not show default product listing.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -22,3 +22,11 @@ Adjusts internal WordPress rewrite rule structure; not necessarily compatible wi
 = Requirements =
 
 * PHP 7.0 or later.
+
+= Configuration =
+
+To only show the Shop page content on the WooCommerce Shop page without the
+regular product listing, set a constant in `wp-config.php`:
+```
+const WOOCOMMERCE_PERMALINK_STRUCTURE_SHOP_PAGE_CONTENT_ONLY = TRUE;
+```

--- a/README.txt
+++ b/README.txt
@@ -2,8 +2,8 @@
 Contributors: netzstrategen
 Tags: permalink, woocommerce
 Requires at least: 4.5
-Tested up to: 4.9.8
-Stable tag: 1.1.3
+Tested up to: 5.9.1
+Stable tag: 1.2.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 /*
   Plugin Name: WooCommerce Permalink Structure
   Plugin URI: http://wordpress.org/plugins/woocommerce-permalink-structure/
-  Version: 1.1.3
+  Version: 1.2.1
   Text Domain: woocommerce-permalink-structure
   Description: Allows WooCommerce products to have the same permalink path prefix as product categories and the shop base page; i.e., '/shop/category/subcategory/product-name'. Adjusts internal WordPress rewrite rule structure; not necessarily compatible with all plugins and shop configurations.
   Author: Daniel F. Kudwien (sun)

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -78,8 +78,9 @@ class Plugin {
     // additional rewrite rules, to enforce the product archive listing on the
     // shop page instead of the shop page content:
     //   shop/?$    index.php?post_type=product    other
-    // Override this to show the shop page content.
-    if (isset($query_vars['post_type']) && $query_vars === ['post_type' => 'product']) {
+    // Override this to only show the shop page content, if configured.
+    if (defined('WOOCOMMERCE_PERMALINK_STRUCTURE_SHOP_PAGE_CONTENT_ONLY') && WOOCOMMERCE_PERMALINK_STRUCTURE_SHOP_PAGE_CONTENT_ONLY
+        && isset($query_vars['post_type']) && $query_vars === ['post_type' => 'product']) {
       // A shop page might be set but may not exist.
       // is_shop() returns false in this early bootstrap phase.
       if (($shop_page_id = wc_get_page_id('shop')) && ($shop_page = get_post($shop_page_id))) {


### PR DESCRIPTION
### Ticket
- [Install WordPress Updates](https://app.asana.com/0/809933051638353/1201784670018421)

### Description
- #9 introduced a regression, causing the shop page to be always replaced with the page content only. However, this was a custom requirement of a particular project only. The behavior is now moved behind a configuration constant.
